### PR TITLE
Use bitwise operators in toBits()

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -1,12 +1,12 @@
-function toBits(num,bits)
-    -- returns a table of bits, most significant first.
+function toBits(num, bits)
+    -- returns a string of bits, most significant first.
     bits = bits or math.max(1, select(2, math.frexp(num)))
-    local t = {} -- will contain the bits
-    for b = bits, 1, -1 do
-        t[b] = math.fmod(num, 2)
-        num = math.floor((num - t[b]) / 2)
+
+    local out = ""
+    for b = bits-1, 0, -1 do
+        out = out .. ((num >> b) & 1)
     end
-    return table.concat(t, "")
+    return out
 end
 
 


### PR DESCRIPTION
I don't know what I'm doing in lua 😅 , but `util.lua` looked like it could use some TLC, so here's a small change to just the `toBits()` method for a start. If it works, I might try to do more in `makeFrame()` too.

PR assumes that lua uses a consistent bit representation for integers like javascript (seems to work on OSX Lua CLI 5.4.3, but I have not tested in any of the emulators *cough*)

I also didn't do a speed comparison test (I just assume using bitwise operators are faster 😑).

Ref:
https://www.lua.org/manual/5.3/manual.html#3.4.2