### PR TITLE
Set "tcp-nodelay" on the socket

### DIFF
--- a/nestrischamps/lib/websocket.lua
+++ b/nestrischamps/lib/websocket.lua
@@ -223,6 +223,7 @@ function wsopen( url )
 	end
 	wsconn.socket = sock
 	wsconn.socket:setoption( 'keepalive', true )
+	wsconn.socket:setoption( 'tcp-nodelay', true ) -- we're a real time application of sorts and thus we need to get packets out as soon as possible
 	if proto == "wss" then
 		D("wsopen() preping for SSL connection")
 		local ssl = require "ssl"


### PR DESCRIPTION
This disables Nagle's algorithm[1] which clumps up the packets, which is undesirable since it results in choppy playback unless a buffer is used.
[1] https://en.wikipedia.org/wiki/Nagle%27s_algorithm