### PR TITLE
Fix score on TetrisGYM v5

### DIFF
--- a/nestrischamps/emus/mesen.lua
+++ b/nestrischamps/emus/mesen.lua
@@ -4,6 +4,15 @@ function memory.readbyte(address)
     return emu.read(address, emu.memType.cpuDebug)
 end
 
+function memory.readbyterange(address, bytes)
+    local str = ""
+    for i = 0, bytes - 1 do
+        local chr = string.char(memory.readbyte(address + i))
+        str = str .. chr
+    end
+    return str
+end
+
 function print(...)
     emu.log(...)
 end

--- a/nestrischamps/getters.lua
+++ b/nestrischamps/getters.lua
@@ -7,6 +7,16 @@ function getGameState() -- gameState is a global thing for which menu/demo/gamep
 end
 
 function getScore()
+	local is_gym_v5 = memory.readbyterange(0x075B, 5) == "T-GYM"
+	if is_gym_v5 then
+		local byte1 = string.format("%x", memory.readbyte(0x000C))
+		local byte2 = string.format("%x", memory.readbyte(0x000D))
+		local byte3 = string.format("%x", memory.readbyte(0x000E))
+		local byte4 = string.format("%x", memory.readbyte(0x000F))
+		local score = math.floor(byte4 * 1000000 + byte3 * 10000 + byte2 * 100 + byte1) -- mesen likes to return floats
+		return score
+	end
+
 	local scoreLeft = tonumber(string.format("%x", memory.readbyte(0x0055)))
 
 	local scoreMiddle = tonumber(string.format("%x", memory.readbyte(0x0054)))


### PR DESCRIPTION
GYM v5 reworked scoring and the score sent was incorrect.
(Thank goodness for small miracles and that initMagic location changed
between v4 and v5 so it's possible to tell them apart)