### PR TITLE
feat: update domain from nestrischamps.herokuapp.com to nestrischamps.io

### DIFF
--- a/nestrischamps/emus/fceux.lua
+++ b/nestrischamps/emus/fceux.lua
@@ -2,7 +2,7 @@ require("iuplua")
 local dialog
 
 function createDialog()
-    local defaultUrl = DEFAULTURL or "ws://nestrischamps.herokuapp.com/ws/room/producer"
+    local defaultUrl = DEFAULTURL or "ws://nestrischamps.io/ws/room/producer"
     local defaultSecret = DEFAULTSECRET or ""
 
     local urlInput = iup.text{size="400x",value=defaultUrl}

--- a/nestrischamps/environment.lua.example
+++ b/nestrischamps/environment.lua.example
@@ -1,4 +1,4 @@
-DEFAULTURL = "ws://nestrischamps.herokuapp.com/ws/room/producer"
+DEFAULTURL = "ws://nestrischamps.io/ws/room/producer"
 DEFAULTSECRET = ""
 
 AUTOCONNECT = false -- skips the dialog and uses the above values instead

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,6 @@ Because OCR is slow and unnecessary for emulators.
 - Go to Tools -> Lua Console
 - Go to Script -> Open Script and browse to nestrischamps.lua
 
-If it worked, it should say "Connected successfully!". You can then go to your renderer (go to https://nestrischamps.herokuapp.com/renderers and select Simple 1p) and it should display any game you start.
+If it worked, it should say "Connected successfully!". You can then go to your renderer (go to https://nestrischamps.io/renderers and select Simple 1p) and it should display any game you start.
 
-You can find your secret on the NestrisChamps settings page, https://nestrischamps.herokuapp.com/settings
+You can find your secret on the NestrisChamps settings page, https://nestrischamps.io/settings


### PR DESCRIPTION
There's a shiny new domain for nestrischamps: nestrischamps.io, so this PR updates the links :) 

Changeset generated with

bash
```
git grep nestrischamps.herokuapp.com | cut -d: -f1 | sort | uniq | while read f; do sed -i '' -e s/nestrischamps.herokuapp.com/nestrischamps.io/ $f; done
```