### PR TITLE
fix: dont send old game data as first frame of new game

### DIFF
--- a/nestrischamps.lua
+++ b/nestrischamps.lua
@@ -68,8 +68,11 @@ function newGameStarted()
 end
 
 
+local DELAY_NEW_GAME_NUM_FRAMES = 1 -- num frames to wait before starting new game
+
 local previousPieceState = -1
 local previousGameState = -1
+local numPendingFrames = -1
 
 playfield.initialize()
 frameManager.update(0, 0)
@@ -83,8 +86,23 @@ function loop()
     local resendFrame = false
 
     if gameState == 4 then --ingame, rocket, highscoreentry
-        if previousGameState ~= 4 then -- just started a game!
-            newGameStarted()
+        if previousGameState ~= 4 then -- possibly just started a game
+            if numPendingFrames < 0 then
+                -- Kinda gross delay before starting a new game :'(
+                -- 1 frame delay is needed because gameState changes before the game data are reset
+                -- We need to avoid sending one frame of old game data into the new game
+                numPendingFrames = DELAY_NEW_GAME_NUM_FRAMES
+            end
+
+            numPendingFrames = numPendingFrames - 1
+
+            if numPendingFrames < 0 then
+                -- delay elapsed, start a new game
+                newGameStarted()
+            else
+                -- delay ongoing, don't do anything
+                return
+            end
         end
 
         if pieceState == 1 then -- piece active


### PR DESCRIPTION
## Context

NTC producers, including the emulator connector, must send the gameid to NTC. NTC split game files for replay based on that. 

game id is coded to change when the game state changes from `not-in-game` (e.g. rocket, high score entry) to `in-game`.

Unfortunately, in ram the game state changes before the game data are reset. So if a producer sends a game frame right away, then a game frame for a new game id will be sent containing the game data of the previous game.

While that is typically not an issue from a rendering perspective, it can break NTC's game block accounting and breaks the detection of piece spawn events, which in turn breaks drought counting, and stack rabbit recommendations.

See discord discussion [here](https://discordapp.com/channels/817528744565932043/863057540970971152/1398876368808443977).


## Approach

This MR introduces a crude 1-frame delay to incrementing the game id and sending game frames to it.

Tested successfully on Mesen 2.1.1 on Windows 11


## Note

Possibly a better long term approach would be to let producers send a continuous stream of game frames, and let NTC server manage the gameid itself. Until that's looked into, this PR should allow the connector to generate clean replay files.


cc @pjvf17