### PR TITLE
fix: fix exception on startup in fceux

### DIFF
--- a/nestrischamps/emus/fceux.lua
+++ b/nestrischamps/emus/fceux.lua
@@ -1,4 +1,7 @@
-require("iuplua")
+if not iup then
+    require("iuplua")
+end
+
 local dialog
 
 function createDialog()


### PR DESCRIPTION
## Context 

In fceux windows, `iup` is a preloaded global constant, and not made available via a local script `iuplua.lua`. That causes the nestrischamps connector to fail on start when running `require("iuplua")` with error

```
module "iuplua" not found
```

## Approach
Guard the statement `require("iuplua")` from the fceux lua script with a conditional check for a pre-existing global `iup`

Tested on fceux 2.6.6 on windows 11