### PR TITLE
fix: increase delay for new game starts

### DIFF
--- a/nestrischamps.lua
+++ b/nestrischamps.lua
@@ -68,7 +68,7 @@ function newGameStarted()
 end
 
 
-local DELAY_NEW_GAME_NUM_FRAMES = 1 -- num frames to wait before starting new game
+local DELAY_NEW_GAME_NUM_FRAMES = 5 -- num frames to wait before starting new game
 
 local previousPieceState = -1
 local previousGameState = -1


### PR DESCRIPTION
## Context

In a [previous PR](https://github.com/Stabyourself/nestrischamps-emulator-connector/pull/8) we introduced a 1-frame delay in starting a new game, to ensure the previous game data was cleared.

Without that 1-frame delay, the last frame of the previous game would be sent into the new game (both board and last piece).

The patch of 1 frame delay worked well for the Vanilla Tetris rom, but unfortunately, it's not enough for [Tetris Gym](https://github.com/kirjavascript/TetrisGYM) v6. With GymV6, 1-frame delay is enough to clear the board, but the last piece of the previous game sticks around for an additional 4 frames.


## Approach 

This PR increased the delay to report a new game to nestrischamps from 1 frame to 5 frames. 

It's not ideal, but since it causes no issue in the nestrischamps replay file, and works with both vanilla and gym v6 roms, it does the trick 🤷 

A separate thread of work could be to look into GymV6 to check if not clearing the last piece is an accident/bug, but this PR is opened to make the game recording work for all users of current GymV6 first, even before a potential fix is added.


## References
* [discord thread](https://discordapp.com/channels/817528744565932043/875591588359831602/1418904482565197935)

